### PR TITLE
fix runtime warning for Pod::POM::ERROR

### DIFF
--- a/bin/podlint
+++ b/bin/podlint
@@ -12,8 +12,12 @@ die usage() if $opts{ h };
 
 my $file = shift || die usage();
 
-my $parser = Pod::POM->new( warn => 1, code => 1 )
+my $parser;
+{
+    no warnings 'once';
+    $parser = Pod::POM->new( warn => 1, code => 1 )
     || die "$Pod::POM::ERROR\n";
+}
 
 my $pom = $parser->parse_file($file)
     || die $parser->error(), "\n";

--- a/bin/pom2
+++ b/bin/pom2
@@ -77,8 +77,12 @@ if (keys %options) {
 Pod::POM->default_view($view)
     || die "$Pod::POM::ERROR\n";
 
-my $parser = Pod::POM->new( warn => 1 )
-    || die "$Pod::POM::ERROR\n";
+my $parser;
+{
+    no warnings 'once'; # $Pod::POM::ERROR is only used once
+    $parser = Pod::POM->new( warn => 1 )
+        || die "$Pod::POM::ERROR\n";
+}
 
 my $pom = $parser->parse_file($file)
     || die $parser->error(), "\n";

--- a/bin/pomdump
+++ b/bin/pomdump
@@ -15,8 +15,12 @@ die usage() if $opts{ h };
 
 my $file = shift || die usage();
 
-my $parser = Pod::POM->new( code => 1 )
+my $parser;
+{
+    no warnings 'once';
+    $parser = Pod::POM->new( code => 1 )
     || die "$Pod::POM::ERROR\n";
+}
 
 my $pom = $parser->parse_file($file)
     || die $parser->error(), "\n";


### PR DESCRIPTION
Hi Neil! Me again :)

This is another tiny PR that updates and applies the patch provided in [RT97554](https://rt.cpan.org/Public/Bug/Display.html?id=97554). The patch is meant to fix some runtime warnings mentioning how `$Pod::POM::ERROR` is used only once. It should be safe to close that ticket after this is merged.

Cheers!
