### PR TITLE
Process L<The Perl Homepage|https://www.perl.org> links

### DIFF
--- a/lib/Pod/POM/View/HTML.pm
+++ b/lib/Pod/POM/View/HTML.pm
@@ -285,7 +285,10 @@ sub view_seq_link {
 
     my $page;
     my $section;
-    if ($link =~ m|^ (.*?) / "? (.*?) "? $|x) { # [name]/"section"
+    if ($link =~ m{^\w+://}s ) { # L<Perl homepage|https://www.perl.org/>
+        return make_href($link,$linktext);
+    }
+    elsif ($link =~ m|^ (.*?) / "? (.*?) "? $|x) { # [name]/"section"
         ($page, $section) = ($1, $2);
     }
     elsif ($link =~ /\s/) {  # this must be a section with missing quotes
@@ -354,6 +357,7 @@ sub make_href {
 my $urls = '(' . join ('|',
      qw{
        http
+       https
        telnet
        mailto
        news
@@ -380,9 +384,10 @@ sub view_seq_text {
 
      $text =~ s{
         \b                           # start at word boundary
+        (?<!\|)                      # but not immediately after a |
          (                           # begin $1  {
            $urls     :               # need resource and a colon
-	  (?!:)                     # Ignore File::, among others.
+           (?!:)                     # Ignore File::, among others.
            [$any] +?                 # followed by one or more of any valid
                                      #   character, but be conservative and
                                      #   take only what you need to....

--- a/t/htmlview.t
+++ b/t/htmlview.t
@@ -202,6 +202,7 @@ This is an email link: mailto:foo@bar.com
 See also L<Test Page 2|pod2>, the L<Your::Module> and L<Their::Module>
 manpages and the other interesting file F</usr/local/my/module/rocks>
 as well.
+If all else fails, consult L<the Perl homepage|https://www.perl.org/>.
 
 =cut
 
@@ -309,7 +310,8 @@ some text
 
 <p>See also <i>Test Page 2</i>, the <i>Your::Module</i> and <i>Their::Module</i>
 manpages and the other interesting file <i>/usr/local/my/module/rocks</i>
-as well.</p>
+as well.
+If all else fails, consult <a href="https://www.perl.org/">the Perl homepage</a>.</p>
 </body>
 </html>
 


### PR DESCRIPTION
This PR is a drive-by finding, so not actually a big problem: I'm working on software (Act) which is using Pod::POM to create its manual and ran into the issue with my own changes to said manual.

Right now, the HTML viewer Pod::POM::View::HTML doesn't handle links like `L<The Perl Homepage|https://www.perl.org>` correctly.  The parser handles `L<...>` elements like any other elements, treating the content as a simple text sequence.  Therefore, the HTML viewer blindly wraps the URL into an `a` element, leaving the link handler confused.

The patch doesn't fix the parser, but works around the problem in the HTML viewer.  It isn't perfect: If a text contains a vertical bar followed by an URL like `|https://www.perl.org/` outside of a `L<...>` element, then this URL is no longer wrapped to a hyperlink.

There's also an extra line for a test case which shows the problem if the patch isn't applied.