### PR TITLE
handle windows path sep

### DIFF
--- a/t/PodPOMTestLib.pm
+++ b/t/PodPOMTestLib.pm
@@ -80,7 +80,7 @@ sub run_tests {
 
 sub get_tests {
     my ($type, $subtype) = @_;
-    (my $testcasedir = $0) =~ s{([^/]+)\.t}{testcases/};
+    (my $testcasedir = $0) =~ s{([^/^\\]+)\.t}{testcases/};
     my (@tests, $testno);
 
     my $expect_ext = $type;


### PR DESCRIPTION
This fixes a fail in the test suite on Windows 10 + Visual C++ Perl build.  Although most of the runs in the cpantesters matrix are pass, I did find one FAIL that is similar to the one that I am seeing:

http://www.cpantesters.org/cpan/report/a8737147-6ca7-1014-adbc-6ec850d68e74